### PR TITLE
fix: re-add `-v` && `-vv` flag for verbose logging

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -26,19 +26,7 @@ func init() {
 }
 
 func setGlobalCliOptions() {
-	// setup global CLI options (available on all CLI commands)
 	rootCmd.PersistentFlags().StringVarP(&cliOnlyOpts.ConfigPath, "config", "c", "", "application config file")
-
-	flag := "quiet"
-	rootCmd.PersistentFlags().BoolP(
-		flag, "q", false,
-		"suppress all logging output",
-	)
-	if err := viper.BindPFlag(flag, rootCmd.PersistentFlags().Lookup(flag)); err != nil {
-		fmt.Printf("unable to bind flag '%s': %+v", flag, err)
-		os.Exit(1)
-	}
-
 	rootCmd.PersistentFlags().CountVarP(&cliOnlyOpts.Verbosity, "verbose", "v", "increase verbosity (-v = info, -vv = debug)")
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,7 +93,7 @@ func (anchore *AnchoreInfo) IsValid() bool {
 }
 
 func setNonCliDefaultValues(v *viper.Viper) {
-	v.SetDefault("log.level", "info")
+	v.SetDefault("log.level", "")
 	v.SetDefault("log.file", "")
 	v.SetDefault("dev.profile-cpu", false)
 	v.SetDefault("dev.log", false)
@@ -143,6 +143,21 @@ func (cfg *Application) Build() error {
 
 	runMode := mode.ParseMode(cfg.Mode)
 	cfg.RunMode = runMode
+
+	if cfg.Log.Level != "" {
+		if cfg.CliOptions.Verbosity > 0 {
+			return fmt.Errorf("cannot explicitly set log level (cfg file or env var) and use -v flag together")
+		}
+	} else {
+		switch v := cfg.CliOptions.Verbosity; {
+		case v == 1:
+			cfg.Log.Level = "info"
+		case v >= 2:
+			cfg.Log.Level = "debug"
+		default:
+			cfg.Log.Level = "error"
+		}
+	}
 
 	// add new policies here if we decide to support more
 	policies := []string{"digest", "insert", "drop"}


### PR DESCRIPTION
This was removed by accident in https://github.com/anchore/elastic-container-gatherer/commit/62b6b50db0af97c6d07402d70c0e657596d3d9f2