### PR TITLE
fix: ensure Report reponse object matches current Anchore API

### DIFF
--- a/ecg/inventory/report.go
+++ b/ecg/inventory/report.go
@@ -1,7 +1,9 @@
 package inventory
 
 type Report struct {
-	Timestamp     string       `json:"timestamp,omitempty"` // Should be generated using time.Now.UTC() and formatted according to RFC Y-M-DTH:M:SZ
-	Results       []ReportItem `json:"results"`
-	InventoryType string       `json:"inventory_type"`
+	Timestamp   string       `json:"timestamp,omitempty"` // Should be generated using time.Now.UTC() and formatted according to RFC Y-M-DTH:M:SZ
+	Results     []ReportItem `json:"results"`
+	ClusterName string       `json:"clusterName,omitempty"` // NOTE: The key here is ClusterName to match the Anchore API but it's actually the region
+
+	InventoryType string `json:"inventory_type"`
 }

--- a/ecg/inventory/reportitem.go
+++ b/ecg/inventory/reportitem.go
@@ -6,8 +6,8 @@ import (
 
 // ReportItem represents a cluster and all it's unique images
 type ReportItem struct {
-	ClusterARN string        `json:"cluster_arn,omitempty"`
-	Images     []ReportImage `json:"images"`
+	Namespace string        `json:"namespace,omitempty"` //NOTE The key is Namespace to match the Anchore API but it's actually the cluster ARN
+	Images    []ReportImage `json:"images"`
 }
 
 // ReportImage represents a unique image in a cluster
@@ -18,7 +18,7 @@ type ReportImage struct {
 
 // String represent the ReportItem as a string
 func (r *ReportItem) String() string {
-	return fmt.Sprintf("ReportItem(cluster=%s, images=%v)", r.ClusterARN, r.Images)
+	return fmt.Sprintf("ReportItem(cluster=%s, images=%v)", r.Namespace, r.Images)
 }
 
 // key will return a unique key for a ReportImage

--- a/ecg/lib.go
+++ b/ecg/lib.go
@@ -90,14 +90,15 @@ func GetInventoryReport(cfg *config.Application) (inventory.Report, error) {
 		images, err := fetchImagesFromTasks(ecsClient, *cluster, tasks)
 
 		results = append(results, inventory.ReportItem{
-			ClusterARN: *cluster,
-			Images:     images,
+			Namespace: *cluster, //NOTE The key is Namespace to match the Anchore API but it's actually the cluster ARN
+			Images:    images,
 		})
 	}
 
 	return inventory.Report{
 		Timestamp:     time.Now().UTC().Format(time.RFC3339),
 		Results:       results,
+		ClusterName:   cfg.Region, // NOTE: The key here is ClusterName to match the Anchore API but it's actually the region
 		InventoryType: "ecs",
 	}, nil
 }

--- a/ecg/presenter/table/presenter.go
+++ b/ecg/presenter/table/presenter.go
@@ -28,7 +28,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 
 	columns := []string{"Image Tag", "Repo Digest", "Cluster"}
 	for _, n := range pres.report.Results {
-		cluster := n.ClusterARN
+		cluster := n.Namespace
 		for _, image := range n.Images {
 			row := []string{image.Tag, image.RepoDigest, cluster}
 			rows = append(rows, row)


### PR DESCRIPTION
Even though namespace/clustername may not be accurate descriptions for ECS based workflow we are overloading those terms here to get something working in Enterprise without API changes.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>