### PR TITLE
fix: restore zapcore import

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 type Logger struct {


### PR DESCRIPTION
I merged a PR that removed this import, after a new one that relied on it. Derp.