### PR TITLE
chore: add debugf func

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -15,6 +15,10 @@ func (log Logger) Debug(msg string, args ...interface{}) {
 	log.zap.Debugw(msg, args...)
 }
 
+func (log Logger) Debugf(msg string, args ...interface{}) {
+	log.zap.Debugf(msg, args...)
+}
+
 func (log Logger) Info(msg string, args ...interface{}) {
 	log.zap.Infow(msg, args...)
 }


### PR DESCRIPTION
String formatting usually isn't a great idea with logs because it can ruin indexing, but for debug level logs its fine as they aren't active for normal operation. Marking as a chore because this function isn't actually called anywhere yet