### PR TITLE
feat: rename from ecg to anchore-ecs-inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # most likely a binary from ad hoc go build
-/elastic-container-gatherer
+/anchore-ecs-inventory
 
 # Editor specific files
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 
 WORKDIR /tmp
 
-COPY ecg /
+COPY anchore-ecs-inventory /
 
 ARG BUILD_DATE
 ARG BUILD_VERSION
@@ -22,4 +22,4 @@ LABEL org.opencontainers.image.description="AEI (Anchore ECS Inventory) is a too
 LABEL org.opencontainers.image.vendor="Anchore, Inc."
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-ENTRYPOINT ["/ecg"]
+ENTRYPOINT ["/anchore-ecs-inventory"]

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# ECG: Elastic Container Gatherer
+# Anchore ECS Inventory
 
-ECG is a tool to gather an inventory of images in use by Amazon Elastic
+`anchore-ecs-inventory` is a tool to gather an inventory of images in use by Amazon Elastic
 Container Service (ECS).
 
 ## Usage
 
-ECG is a command line tool. It can be run with the following command:
+`anchore-ecs-inventory` is a command line tool. It can be run with the following command:
 
 ```
-$ ./ecg --help
+$ ./anchore-ecs-inventory --help
 ECG (Elastic Container Gatherer) can poll Amazon ECS (Elastic Container Service) APIs to tell Anchore which Images are currently in-use
 
 Usage:
-ecg [flags]
-ecg [command]
+anchore-ecs-inventory [flags]
+anchore-ecs-inventory [command]
 
 Available Commands:
 completion  Generate Completion script
@@ -22,21 +22,21 @@ version     show the version
 
 Flags:
 -c, --config string                     application config file
--h, --help                              help for ecg
+-h, --help                              help for anchore-ecs-inventory
 -p, --polling-interval-seconds string   This specifies the polling interval of the ECS API in seconds (default "300")
 -r, --region string                     If set overrides the AWS_REGION environment variable/region specified in ECG config
 -v, --verbose count                     increase verbosity (-v = info, -vv = debug)
 
-Use "ecg [command] --help" for more information about a command.
+Use "anchore-ecs-inventory [command] --help" for more information about a command.
 ```
 
 ## Configuration
 
-ECG needs to be configured with AWS credentials and ECG configuration.
+`anchore-ecs-inventory` needs to be configured with AWS credentials and Anchore ECS Inventory configuration.
 
 ### AWS Credentials
 
-ECG uses the AWS SDK for Go. The SDK will look for credentials in the following
+Anchore ECS Inventory uses the AWS SDK for Go. The SDK will look for credentials in the following
 order:
 
 1. Environment variables
@@ -47,21 +47,21 @@ order:
     aws_secret_access_key = <YOUR_SECRET_ACCESS_KEY>
     ```
 
-### ECG Configuration
+### Anchore ECS Inventory Configuration
 
-ECG can be configured with a configuration file. The default location the configuration
-file is looked for is `~/.ecg/config.yaml`. The configuration file can be overridden with
+Anchore ECS Inventory can be configured with a configuration file. The default location the configuration
+file is looked for is `~/.anchore-ecs-inventory/config.yaml`. The configuration file can be overridden with
 the `-c` flag.
 
 ```
 log:
   level: "debug"
   # location to write the log file (default is not to have a log file)
-  file: "./ecg.log"
+  file: "./anchore-ecs-inventory.log"
 
 anchore:
   url: <your anchore api url> (e.g. http://localhost:8228)
-  user: <ecg_inventory_user>
+  user: <anchore-ecs-inventory_inventory_user>
   password: $ECG_ANCHORE_PASSWORD
   http:
     insecure: true

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -7,14 +7,16 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/anchore/elastic-container-gatherer/ecg"
-	"github.com/anchore/elastic-container-gatherer/internal/config"
-	"github.com/anchore/elastic-container-gatherer/internal/logger"
+	"github.com/anchore/anchore-ecs-inventory/ecg"
+	"github.com/anchore/anchore-ecs-inventory/internal/config"
+	"github.com/anchore/anchore-ecs-inventory/internal/logger"
 )
 
-var appConfig *config.AppConfig
-var cliOnlyOpts config.CliOnlyOptions
-var log logger.Logger
+var (
+	appConfig   *config.AppConfig
+	cliOnlyOpts config.CliOnlyOptions
+	log         logger.Logger
+)
 
 func init() {
 	setGlobalCliOptions()

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -14,13 +14,13 @@ var completionCmd = &cobra.Command{
 
 Bash:
 
-$ source <(ecg completion bash)
+$ source <(anchore-ecs-inventory completion bash)
 
 # To load completions for each session, execute once:
 Linux:
-  $ ecg completion bash > /etc/bash_completion.d/ecg
+  $ anchore-ecs-inventory completion bash > /etc/bash_completion.d/anchore-ecs-inventory
 MacOS:
-  $ ecg completion bash > /usr/local/etc/bash_completion.d/ecg
+  $ anchore-ecs-inventory completion bash > /usr/local/etc/bash_completion.d/anchore-ecs-inventory
 
 Zsh:
 
@@ -30,16 +30,16 @@ Zsh:
 $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
 # To load completions for each session, execute once:
-$ ecg completion zsh > "${fpath[1]}/_ecg"
+$ anchore-ecs-inventory completion zsh > "${fpath[1]}/_anchore-ecs-inventory"
 
 # You will need to start a new shell for this setup to take effect.
 
 Fish:
 
-$ ecg completion fish | source
+$ anchore-ecs-inventory completion fish | source
 
 # To load completions for each session, execute once:
-$ ecg completion fish > ~/.config/fish/completions/ecg.fish
+$ anchore-ecs-inventory completion fish > ~/.config/fish/completions/anchore-ecs-inventory.fish
 `,
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish"},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,15 +8,15 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/anchore/elastic-container-gatherer/ecg"
-	"github.com/anchore/elastic-container-gatherer/internal/config"
+	"github.com/anchore/anchore-ecs-inventory/ecg"
+	"github.com/anchore/anchore-ecs-inventory/internal/config"
 )
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "ecg",
-	Short: "ECG tells Anchore which images are in use in your ECS clusters",
-	Long:  "ECG (Elastic Container Gatherer) can poll Amazon ECS (Elastic Container Service) APIs to tell Anchore which Images are currently in-use",
+	Use:   "anchore-ecs-inventory",
+	Short: "anchore-ecs-inventory tells Anchore which images are in use in your ECS clusters",
+	Long:  "anchore-ecs-inventory can poll Amazon ECS (Elastic Container Service) APIs to tell Anchore which Images are currently in-use",
 	Args:  cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 0 {
@@ -49,14 +49,16 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	opt := "polling-interval-seconds"
-	rootCmd.Flags().StringP(opt, "p", strconv.Itoa(config.DefaultConfigValues.PollingIntervalSeconds), "This specifies the polling interval of the ECS API in seconds")
+	rootCmd.Flags().
+		StringP(opt, "p", strconv.Itoa(config.DefaultConfigValues.PollingIntervalSeconds), "This specifies the polling interval of the ECS API in seconds")
 	if err := viper.BindPFlag(opt, rootCmd.Flags().Lookup(opt)); err != nil {
 		fmt.Printf("unable to bind flag '%s': %+v", opt, err)
 		os.Exit(1)
 	}
 
 	opt = "region"
-	rootCmd.Flags().StringP(opt, "r", config.DefaultConfigValues.Region, "If set overrides the AWS_REGION environment variable/region specified in ECG config")
+	rootCmd.Flags().
+		StringP(opt, "r", config.DefaultConfigValues.Region, "If set overrides the AWS_REGION environment variable/region specified in anchore-ecs-inventory config")
 	if err := viper.BindPFlag(opt, rootCmd.Flags().Lookup(opt)); err != nil {
 		fmt.Printf("unable to bind flag '%s': %+v", opt, err)
 		os.Exit(1)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/anchore/elastic-container-gatherer/internal"
-	"github.com/anchore/elastic-container-gatherer/internal/version"
+	"github.com/anchore/anchore-ecs-inventory/internal"
+	"github.com/anchore/anchore-ecs-inventory/internal/version"
 )
 
 var outputFormat string
@@ -20,7 +20,8 @@ var versionCmd = &cobra.Command{
 }
 
 func init() {
-	versionCmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "format to show version information (available=[text, json])")
+	versionCmd.Flags().
+		StringVarP(&outputFormat, "output", "o", "text", "format to show version information (available=[text, json])")
 
 	rootCmd.AddCommand(versionCmd)
 }

--- a/docker-compose/config.yaml
+++ b/docker-compose/config.yaml
@@ -1,7 +1,7 @@
 log:
   level: "info"
   # location to write the log file (default is not to have a log file)
-  file: "./ecg.log"
+  file: "./anchore-ecs-inventory.log"
 
 anchore:
   url: http://localhost:8228

--- a/ecg/lib.go
+++ b/ecg/lib.go
@@ -10,10 +10,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
 
-	"github.com/anchore/elastic-container-gatherer/ecg/connection"
-	"github.com/anchore/elastic-container-gatherer/ecg/inventory"
-	"github.com/anchore/elastic-container-gatherer/ecg/logger"
-	"github.com/anchore/elastic-container-gatherer/ecg/reporter"
+	"github.com/anchore/anchore-ecs-inventory/ecg/connection"
+	"github.com/anchore/anchore-ecs-inventory/ecg/inventory"
+	"github.com/anchore/anchore-ecs-inventory/ecg/logger"
+	"github.com/anchore/anchore-ecs-inventory/ecg/reporter"
 )
 
 var log logger.Logger

--- a/ecg/reporter/reporter.go
+++ b/ecg/reporter/reporter.go
@@ -10,9 +10,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/anchore/elastic-container-gatherer/ecg/connection"
-	"github.com/anchore/elastic-container-gatherer/ecg/inventory"
-	"github.com/anchore/elastic-container-gatherer/internal/logger"
+	"github.com/anchore/anchore-ecs-inventory/ecg/connection"
+	"github.com/anchore/anchore-ecs-inventory/ecg/inventory"
+	"github.com/anchore/anchore-ecs-inventory/internal/logger"
 )
 
 const ReportAPIPath = "v1/enterprise/inventories"

--- a/ecg/reporter/reporter_test.go
+++ b/ecg/reporter/reporter_test.go
@@ -3,7 +3,7 @@ package reporter
 import (
 	"testing"
 
-	"github.com/anchore/elastic-container-gatherer/ecg/connection"
+	"github.com/anchore/anchore-ecs-inventory/ecg/connection"
 )
 
 func TestBuildUrl(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/anchore/elastic-container-gatherer
+module github.com/anchore/anchore-ecs-inventory
 
 go 1.19
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,11 +2,11 @@
 The Config package handles the application configuration. Configurations can come from a variety of places, and
 are listed below in order of precedence:
   - Command Line
-  - .ecg.yaml
-  - .ecg/config.yaml
-  - ~/.ecg.yaml
-  - <XDG_CONFIG_HOME>/ecg/config.yaml
-  - Environment Variables prefixed with ECG_
+  - .anchore-ecs-inventory.yaml
+  - .anchore-ecs-inventory/config.yaml
+  - ~/.anchore-ecs-inventory.yaml
+  - <XDG_CONFIG_HOME>/anchore-ecs-inventory/config.yaml
+  - Environment Variables prefixed with ANCHORE-ECS-INVENTORY_
 */
 package config
 
@@ -20,8 +20,8 @@ import (
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 
-	"github.com/anchore/elastic-container-gatherer/ecg/connection"
-	"github.com/anchore/elastic-container-gatherer/internal"
+	"github.com/anchore/anchore-ecs-inventory/ecg/connection"
+	"github.com/anchore/anchore-ecs-inventory/internal"
 )
 
 const redacted = "******"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/anchore/elastic-container-gatherer/ecg/connection"
+	"github.com/anchore/anchore-ecs-inventory/ecg/connection"
 )
 
 func TestLoadConfigFromFileCliConfigPath(t *testing.T) {
@@ -25,7 +25,7 @@ func TestLoadConfigFromFileCliConfigPath(t *testing.T) {
 		},
 		Log: Logging{
 			Level:        "info",
-			FileLocation: "/var/log/ecg.log",
+			FileLocation: "/var/log/anchore-ecs-inventory.log",
 		},
 		AnchoreDetails: connection.AnchoreInfo{
 			Account:  "admin",
@@ -58,7 +58,7 @@ func TestLoadConfigFromFileBadCliConfig(t *testing.T) {
 func TestReadConfigNoConfigsPresent(t *testing.T) {
 	t.Cleanup(cleanup)
 
-	err := readConfig(viper.GetViper(), "", "ecg-but-not-really-lets-break-this-test")
+	err := readConfig(viper.GetViper(), "", "anchore-ecs-inventory-but-not-really-lets-break-this-test")
 
 	assert.Error(t, err)
 }

--- a/internal/config/testdata/config.yaml
+++ b/internal/config/testdata/config.yaml
@@ -1,6 +1,6 @@
 log:
   level: "info"
-  file: "/var/log/ecg.log"
+  file: "/var/log/anchore-ecs-inventory.log"
 
 anchore:
   url: http://localhost:8228

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -1,4 +1,4 @@
 package internal
 
 // note: do not change this
-const ApplicationName = "ecg"
+const ApplicationName = "anchore-ecs-inventory"

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/anchore/elastic-container-gatherer/cmd"
+import "github.com/anchore/anchore-ecs-inventory/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
This keeps the ecg package/directory for now but this will shortly change to pkg
and have smaller exportable packages inside of it.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
