### PR TITLE
feat: validate connection/creds to Anchore

### DIFF
--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -48,6 +48,9 @@ func Post(report Report, anchoreDetails connection.AnchoreInfo) error {
 	req.Header.Set("x-anchore-account", anchoreDetails.Account)
 	resp, err := client.Do(req)
 	if err != nil {
+		if resp.StatusCode == 401 {
+			return fmt.Errorf("failed to report data to Anchore, check credentials: %w", err)
+		}
 		return fmt.Errorf("failed to report data to Anchore: %w", err)
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
The dummy report post to ecs-inventory will be replaced with the agent health check API once that is available.