### PR TITLE
feat: remove metadata config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,6 @@ region: $ANCHORE_ECS_INVENTORY_REGION
 polling-interval-seconds: 300
 
 quiet: false
-
-# collect additional metadata about where a container is running (service/task metadata including tags). [defaults to true]
-metadata: true
 ```
 
 You can also override any configuration value with environment variables. They

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,7 +65,6 @@ var rootCmd = &cobra.Command{
 			appConfig.Region,
 			appConfig.Quiet,
 			appConfig.DryRun,
-			appConfig.Metadata,
 		)
 	},
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,9 +38,8 @@ type AppConfig struct {
 	PollingIntervalSeconds int                    `mapstructure:"polling-interval-seconds"`
 	AnchoreDetails         connection.AnchoreInfo `mapstructure:"anchore"`
 	Region                 string                 `mapstructure:"region"`
-	Quiet                  bool                   `mapstructure:"quiet"`    // if true do not log the inventory report to stdout
-	DryRun                 bool                   `mapstructure:"dry-run"`  // if true do not report inventory to Anchore
-	Metadata               bool                   `mapstructure:"metadata"` // if true, include runtime metadata in the inventory report
+	Quiet                  bool                   `mapstructure:"quiet"`   // if true do not log the inventory report to stdout
+	DryRun                 bool                   `mapstructure:"dry-run"` // if true do not report inventory to Anchore
 }
 
 // Logging Configuration
@@ -65,7 +64,6 @@ var DefaultConfigValues = AppConfig{
 	PollingIntervalSeconds: 300,
 	Quiet:                  false,
 	DryRun:                 false,
-	Metadata:               true,
 }
 
 var ErrConfigFileNotFound = fmt.Errorf("application config file not found")
@@ -76,7 +74,6 @@ func setDefaultValues(v *viper.Viper) {
 	v.SetDefault("anchore.account", DefaultConfigValues.AnchoreDetails.Account)
 	v.SetDefault("anchore.http.insecure", DefaultConfigValues.AnchoreDetails.HTTP.Insecure)
 	v.SetDefault("anchore.http.timeout-seconds", DefaultConfigValues.AnchoreDetails.HTTP.TimeoutSeconds)
-	v.SetDefault("metadata", DefaultConfigValues.Metadata)
 }
 
 // Load the Application Configuration from the Viper specifications

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,7 +40,6 @@ func TestLoadConfigFromFileCliConfigPath(t *testing.T) {
 		Region:                 "us-east-1",
 		PollingIntervalSeconds: 60,
 		Quiet:                  true,
-		Metadata:               true,
 	}
 
 	assert.EqualValues(t, expectedCfg, appCfg)
@@ -101,7 +100,6 @@ anchoredetails:
 region: ""
 quiet: false
 dryrun: false
-metadata: false
 `
 
 	assert.Equal(t, expected, config.String())
@@ -134,7 +132,6 @@ func TestDefaultValuesSuppliedForEmptyConfig(t *testing.T) {
 				TimeoutSeconds: 10,
 			},
 		},
-		Metadata: true,
 	}
 
 	assert.EqualValues(t, expectedCfg, appCfg)

--- a/pkg/inventory/report_test.go
+++ b/pkg/inventory/report_test.go
@@ -10,7 +10,7 @@ import (
 func TestGetInventoryReportForCluster(t *testing.T) {
 	mockSvc := &mockECSClient{}
 
-	report, err := GetInventoryReportForCluster("cluster-1", mockSvc, true)
+	report, err := GetInventoryReportForCluster("cluster-1", mockSvc)
 
 	assert.NoError(t, err)
 	fmt.Println(report)

--- a/pkg/lib.go
+++ b/pkg/lib.go
@@ -16,13 +16,13 @@ func PeriodicallyGetInventoryReport(
 	pollingIntervalSeconds int,
 	anchoreDetails connection.AnchoreInfo,
 	region string,
-	quiet, dryRun, metadata bool,
+	quiet, dryRun bool,
 ) {
 	// Fire off a ticker that reports according to a configurable polling interval
 	ticker := time.NewTicker(time.Duration(pollingIntervalSeconds) * time.Second)
 
 	for {
-		err := inventory.GetInventoryReportsForRegion(region, anchoreDetails, quiet, dryRun, metadata)
+		err := inventory.GetInventoryReportsForRegion(region, anchoreDetails, quiet, dryRun)
 		if err != nil {
 			log.Error("Failed to get Inventory Reports for region", err)
 		}


### PR DESCRIPTION
This will be rethought in a future release. For now ecs-inventory will
only send to Anchore Enterprise with all metadata.

