### PR TITLE
feat: add a build that uses boring crypto to run on fips enabled hosts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,7 @@ release:
 
 builds:
   - binary: anchore-ecs-inventory
+    id: generic
     env:
       - CGO_ENABLED=0
     goos:
@@ -21,10 +22,38 @@ builds:
       -X github.com/anchore/ecs-inventory/internal/version.gitCommit={{.Commit}}
       -X github.com/anchore/ecs-inventory/internal/version.buildDate={{.Date}}
       -X github.com/anchore/ecs-inventory/internal/version.gitDescription={{.Summary}}
-
+  - binary: anchore-ecs-inventory
+    id: fips
+    env:
+      - CGO_ENABLED=1
+      - GOEXPERIMENT=boringcrypto
+    goos:
+      - linux
+    goarch:
+      - amd64
+    # Set the modified timestamp on the output binary to the git timestamp (to ensure a reproducible build)
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    ldflags: |
+      -w
+      -linkmode=external
+      -extldflags '-static'
+      -X github.com/anchore/ecs-inventory/internal/version.version={{.Version}}
+      -X github.com/anchore/ecs-inventory/internal/version.gitCommit={{.Commit}}
+      -X github.com/anchore/ecs-inventory/internal/version.buildDate={{.Date}}
+      -X github.com/anchore/ecs-inventory/internal/version.gitDescription={{.Summary}}
 
 archives:
-  - format: tar.gz
+  - id: archive-generic
+    format: tar.gz
+    builds:
+      - generic
+    name_template: 'anchore-ecs-inventory_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+  - id: archive-fips
+    format: tar.gz
+    builds:
+      - fips
+    name_template: 'anchore-ecs-inventory-fips_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+
 
 changelog:
   sort: asc
@@ -41,6 +70,8 @@ dockers:
       - "anchore/ecs-inventory:v{{ .Major }}.{{ .Minor }}-amd64"
     dockerfile: Dockerfile
     use: buildx
+    ids:
+      - generic
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=BUILD_DATE={{.Date}}"
@@ -55,8 +86,23 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     use: buildx
+    ids:
+      - generic
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  - image_templates:
+      - "anchore/ecs-inventory:{{ .Tag }}-fips-amd64"
+    dockerfile: Dockerfile
+    use: buildx
+    ids:
+      - fips
+    build_flag_templates:
+      - "--platform=linux/amd64"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
@@ -66,6 +112,7 @@ docker_manifests:
   - name_template: anchore/ecs-inventory:{{ .Tag }}
     image_templates:
       - anchore/ecs-inventory:{{ .Tag }}-amd64
+      - anchore/ecs-inventory:{{ .Tag }}-fips-amd64
       - anchore/ecs-inventory:v{{ .Major }}-amd64
       - anchore/ecs-inventory:v{{ .Major }}.{{ .Minor }}-amd64
       - anchore/ecs-inventory:{{ .Tag }}-arm64v8
@@ -74,6 +121,7 @@ docker_manifests:
   - name_template: anchore/ecs-inventory:latest
     image_templates:
       - anchore/ecs-inventory:{{ .Tag }}-amd64
+      - anchore/ecs-inventory:{{ .Tag }}-fips-amd64
       - anchore/ecs-inventory:v{{ .Major }}-amd64
       - anchore/ecs-inventory:v{{ .Major }}.{{ .Minor }}-amd64
       - anchore/ecs-inventory:{{ .Tag }}-arm64v8


### PR DESCRIPTION
A new build has been added that uses CGO and the boring crypto build flag to substitute go's default crypto library with boring crypto to ensure the binary can run on FIPs enabled hosts. The fips build includes the go symbol table in the binary (note other builds include -s to strip it), this allows you to run `go tool nm anchore-ecs-inventory | grep '_Cfunc__goboringcrypto_'` to verify that the binary was built with boringcrypto.

A docker image will also be built with the tag `v1.0.0-fips-amd64` that includes the -fips binary.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
