### PR TITLE
chore: change no anchore details log to a warn

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,7 @@ var rootCmd = &cobra.Command{
 				log.Info("Successfully validated connection to Anchore")
 			}
 		} else {
-			log.Debug("Anchore details not specified, will not report inventory")
+			log.Warn("Anchore details not specified, will not report inventory")
 		}
 
 		pkg.PeriodicallyGetInventoryReport(

--- a/pkg/inventory/report.go
+++ b/pkg/inventory/report.go
@@ -38,7 +38,7 @@ func HandleReport(report reporter.Report, anchoreDetails connection.AnchoreInfo,
 			return fmt.Errorf("unable to report Inventory to Anchore: %w", err)
 		}
 	default:
-		logger.Log.Debug("Anchore details not specified, not reporting inventory")
+		logger.Log.Warn("Anchore details not specified, not reporting inventory")
 	}
 
 	if !quiet {


### PR DESCRIPTION
Ensure users see the warning message (without enabling debug logging)
that the report will not be posted to Anchore if no credentials are
configured.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
