### PR TITLE
ci: don't run commitlint for dependabot PRs

### DIFF
--- a/.github/workflows/commit-linting.yaml
+++ b/.github/workflows/commit-linting.yaml
@@ -4,6 +4,7 @@ on: [pull_request]
 jobs:
   commitlint:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
