### PR TITLE
ci: upgrade goreleaser to v2 to support GitHub immutable releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 release:
   prerelease: auto
 
@@ -44,13 +46,15 @@ builds:
 
 archives:
   - id: archive-generic
-    format: tar.gz
-    builds:
+    formats:
+      - tar.gz
+    ids:
       - generic
     name_template: 'anchore-ecs-inventory_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
   - id: archive-fips
-    format: tar.gz
-    builds:
+    formats:
+      - tar.gz
+    ids:
       - fips
     name_template: 'anchore-ecs-inventory-fips_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
 
@@ -146,4 +150,3 @@ docker_manifests:
       - anchore/ecs-inventory:{{ .Tag }}-amd64
       - anchore/ecs-inventory:{{ .Tag }}-arm64v8
     skip_push: auto
-      

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SUCCESS := $(BOLD)$(GREEN)
 # ci dependency versions
 GOLANG_CI_VERSION = v2.12.2
 GOSIMPORTS_VERSION = v0.3.8
-GORELEASER_VERSION = v1.16.0
+GORELEASER_VERSION = v2.13.3
 
 ## Build variables
 ifeq "$(strip $(VERSION))" ""
@@ -58,7 +58,7 @@ bootstrap-tools: $(TEMPDIR)
 	$(call title,Boostrapping tools)
 	GOBIN="$(abspath $(TEMPDIR))" go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANG_CI_VERSION)
 	GOBIN="$(realpath $(TEMPDIR))" go install github.com/rinchsan/gosimports/cmd/gosimports@$(GOSIMPORTS_VERSION)
-	GOBIN="$(abspath $(TEMPDIR))" go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION)
+	GOBIN="$(abspath $(TEMPDIR))" go install github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION)
 
 .PHONY: bootstrap
 bootstrap: bootstrap-go bootstrap-tools ## Download and install all go dependencies (+ prep tooling in the ./tmp dir)
@@ -105,7 +105,7 @@ unit: ## Run unit tests (with coverage)
 .PHONY: snapshot
 snapshot: ## Build a snapshot binaries and docker images
 	$(call title,Building snapshot binary)
-	$(TEMPDIR)/goreleaser release --skip-publish --clean --snapshot --config .goreleaser.yaml
+	$(TEMPDIR)/goreleaser release --skip=publish --clean --snapshot --config .goreleaser.yaml
 
 .PHONY: release
 release: ## Publish release binaries and docker images


### PR DESCRIPTION
## Summary
GitHub's **immutable releases** feature freezes a release's assets when the release is created. The pinned **goreleaser v1.16.0** creates the release first and then uploads assets in a separate step, which GitHub now rejects with `422 Cannot upload assets to an immutable release`. As a result, every release since the setting was enabled (**v1.4.2 onward**) published with **zero binary assets**, and the latest RC release job failed outright.

This is not caused by the recent docker-tag-matrix change — it's a pre-existing incompatibility between the old goreleaser and immutable releases.

## Fix
Upgrade to **goreleaser v2**, which uploads assets to a draft and publishes afterward (so assets are attached *before* the release becomes immutable). This matches the working setup in **anchorectl** (goreleaser v2.13.3), whose immutable releases attach all assets correctly.

### Changes
- **Makefile**: `GORELEASER_VERSION` v1.16.0 → v2.13.3; install from the `goreleaser/v2` module path; `--skip-publish` → `--skip=publish`.
- **.goreleaser.yaml**: add `version: 2`; migrate `archives.format` → `formats` and `archives.builds` → `archives.ids` (v2 schema). The docker tag matrix and `release.prerelease: auto` are unchanged.

## Validation
- `goreleaser check` (v2.13.3) passes (exit 0); config valid. Remaining `dockers`/`docker_manifests` → `dockers_v2` notice is a soft long-term phase-out that anchorectl also carries.

## Note
The partial `v1.4.4-rc0` release (immutable, 0 assets) should be deleted before re-releasing so the tag doesn't collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)