### PR TITLE
fix: paginate ECS list calls and batch describe calls (ENTERPRISE-8894)

### DIFF
--- a/pkg/inventory/ecs.go
+++ b/pkg/inventory/ecs.go
@@ -3,6 +3,7 @@ package inventory
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -16,6 +17,16 @@ import (
 )
 
 const unknown = "UNKNOWN"
+
+// Hard AWS limits on how many IDs a single Describe* call accepts.
+const (
+	describeTasksBatchSize    = 100
+	describeServicesBatchSize = 10
+)
+
+// ListServices returns only 10 results per page by default; the other List* calls already
+// default to 100. 100 is the maximum for all of them.
+const listPageSize = 100
 
 // Check if AWS credentials are present in the loaded config
 func checkAWSCredentials(ctx context.Context, cfg aws.Config) error {
@@ -31,58 +42,91 @@ func checkAWSCredentials(ctx context.Context, cfg aws.Config) error {
 
 func fetchClusters(ctx context.Context, client ECSAPI) ([]string, error) {
 	defer tracker.TrackFunctionTime(time.Now(), "Fetching list of clusters")
-	input := &ecs.ListClustersInput{}
 
-	result, err := client.ListClusters(ctx, input)
-	if err != nil {
-		return nil, err
+	var clusterArns []string
+	paginator := ecs.NewListClustersPaginator(client, &ecs.ListClustersInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		clusterArns = append(clusterArns, page.ClusterArns...)
 	}
 
-	return result.ClusterArns, nil
+	return clusterArns, nil
 }
 
 func fetchTasksFromCluster(ctx context.Context, client ECSAPI, cluster string) ([]string, error) {
 	defer tracker.TrackFunctionTime(time.Now(), fmt.Sprintf("Fetching tasks from cluster: %s", cluster))
-	input := &ecs.ListTasksInput{
+
+	var taskArns []string
+	paginator := ecs.NewListTasksPaginator(client, &ecs.ListTasksInput{
 		Cluster: aws.String(cluster),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		taskArns = append(taskArns, page.TaskArns...)
 	}
 
-	result, err := client.ListTasks(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.TaskArns, nil
+	return taskArns, nil
 }
 
 func fetchServicesFromCluster(ctx context.Context, client ECSAPI, cluster string) ([]string, error) {
 	defer tracker.TrackFunctionTime(time.Now(), fmt.Sprintf("Fetching services from cluster: %s", cluster))
-	input := &ecs.ListServicesInput{
+
+	var serviceArns []string
+	paginator := ecs.NewListServicesPaginator(client, &ecs.ListServicesInput{
 		Cluster: aws.String(cluster),
+	}, func(o *ecs.ListServicesPaginatorOptions) {
+		// The paginator overwrites MaxResults on the input with its own Limit, so the page
+		// size has to be set here or every page comes back with the default 10 services.
+		o.Limit = listPageSize
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		serviceArns = append(serviceArns, page.ServiceArns...)
 	}
 
-	result, err := client.ListServices(ctx, input)
-	if err != nil {
-		return nil, err
+	return serviceArns, nil
+}
+
+// describeTasks fetches full detail for every task ARN, split into batches of the size
+// DescribeTasks accepts.
+func describeTasks(ctx context.Context, client ECSAPI, cluster string, taskARNs []string) ([]ecstypes.Task, error) {
+	var tasks []ecstypes.Task
+	for batch := range slices.Chunk(taskARNs, describeTasksBatchSize) {
+		results, err := client.DescribeTasks(ctx, &ecs.DescribeTasksInput{
+			Cluster: aws.String(cluster),
+			Tasks:   batch,
+		})
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, results.Tasks...)
 	}
 
-	return result.ServiceArns, nil
+	return tasks, nil
 }
 
 func fetchContainersFromTasks(ctx context.Context, client ECSAPI, cluster string, tasks []string) ([]reporter.Container, error) {
 	defer tracker.TrackFunctionTime(time.Now(), fmt.Sprintf("Fetching Containers from tasks for cluster: %s", cluster))
-	input := &ecs.DescribeTasksInput{
-		Cluster: aws.String(cluster),
-		Tasks:   tasks,
-	}
 
-	results, err := client.DescribeTasks(ctx, input)
+	// Every task has to be described before the tag map is built: the map resolves image tags
+	// across the whole set, so building it per batch would drop tags that live in another batch.
+	describedTasks, err := describeTasks(ctx, client, cluster, tasks)
 	if err != nil {
 		return nil, err
 	}
-	containerTagMap := buildContainerTagMap(results.Tasks)
+
+	containerTagMap := buildContainerTagMap(describedTasks)
 	containers := []reporter.Container{}
-	for _, task := range results.Tasks {
+	for _, task := range describedTasks {
 		for _, container := range task.Containers {
 			digest := ""
 			if container.ImageDigest != nil {
@@ -180,18 +224,13 @@ func constructServiceARN(clusterARN string, serviceName string) (string, error) 
 }
 
 func fetchTasksMetadata(ctx context.Context, client ECSAPI, cluster string, tasks []string) ([]reporter.Task, error) {
-	input := &ecs.DescribeTasksInput{
-		Cluster: aws.String(cluster),
-		Tasks:   tasks,
-	}
-
-	results, err := client.DescribeTasks(ctx, input)
+	describedTasks, err := describeTasks(ctx, client, cluster, tasks)
 	if err != nil {
 		return nil, err
 	}
 
 	var tasksMetadata []reporter.Task
-	for _, task := range results.Tasks {
+	for _, task := range describedTasks {
 		// Tags may not be present in the task response so we need to fetch them explicitly
 		taskARN := ""
 		if task.TaskArn != nil {
@@ -235,18 +274,20 @@ func fetchTasksMetadata(ctx context.Context, client ECSAPI, cluster string, task
 }
 
 func fetchServicesMetadata(ctx context.Context, client ECSAPI, cluster string, services []string) ([]reporter.Service, error) {
-	input := &ecs.DescribeServicesInput{
-		Cluster:  aws.String(cluster),
-		Services: services,
-	}
-
-	results, err := client.DescribeServices(ctx, input)
-	if err != nil {
-		return nil, err
+	var describedServices []ecstypes.Service
+	for batch := range slices.Chunk(services, describeServicesBatchSize) {
+		results, err := client.DescribeServices(ctx, &ecs.DescribeServicesInput{
+			Cluster:  aws.String(cluster),
+			Services: batch,
+		})
+		if err != nil {
+			return nil, err
+		}
+		describedServices = append(describedServices, results.Services...)
 	}
 
 	var servicesMetadata []reporter.Service
-	for _, service := range results.Services {
+	for _, service := range describedServices {
 		// Tags may not be present in the service response so we need to fetch them explicitly
 		serviceARN := ""
 		if service.ServiceArn != nil {

--- a/pkg/inventory/ecs_test.go
+++ b/pkg/inventory/ecs_test.go
@@ -2,11 +2,13 @@ package inventory
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/ecs-inventory/pkg/reporter"
 )
@@ -643,5 +645,89 @@ func Test_getContainerImageTag(t *testing.T) {
 			got := getContainerImageTag(tt.args.containerTagMap, &tt.args.container)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+func Test_listCallsFollowEveryPage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("clusters", func(t *testing.T) {
+		client := &mockECSClient{
+			ClusterPages: [][]string{{"cluster-1", "cluster-2"}, {"cluster-3"}, {"cluster-4"}},
+		}
+		got, err := fetchClusters(ctx, client)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"cluster-1", "cluster-2", "cluster-3", "cluster-4"}, got)
+	})
+
+	t.Run("tasks", func(t *testing.T) {
+		client := &mockECSClient{
+			TaskPages: [][]string{{"task-1", "task-2"}, {"task-3"}},
+		}
+		got, err := fetchTasksFromCluster(ctx, client, "cluster-1")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"task-1", "task-2", "task-3"}, got)
+	})
+
+	t.Run("services", func(t *testing.T) {
+		client := &mockECSClient{
+			ServicePages: [][]string{{"service-1"}, {"service-2"}, {"service-3"}},
+		}
+		got, err := fetchServicesFromCluster(ctx, client, "cluster-1")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"service-1", "service-2", "service-3"}, got)
+	})
+}
+
+func Test_describeCallsStayWithinBatchLimits(t *testing.T) {
+	ctx := context.Background()
+
+	assertBatched := func(t *testing.T, batches [][]string, want []string, limit int) {
+		t.Helper()
+		var described []string
+		for _, batch := range batches {
+			assert.LessOrEqual(t, len(batch), limit)
+			described = append(described, batch...)
+		}
+		assert.Equal(t, want, described)
+	}
+
+	// The limits are spelled out here rather than reused from the constants the code batches
+	// with, so that a wrong constant fails the test instead of moving the goalposts.
+	t.Run("tasks", func(t *testing.T) {
+		client := &mockECSClient{}
+		tasks := syntheticTaskARNs(201)
+
+		_, err := fetchContainersFromTasks(ctx, client, "cluster-1", tasks)
+		require.NoError(t, err)
+		assertBatched(t, client.DescribeTasksBatches, tasks, 100)
+	})
+
+	t.Run("services", func(t *testing.T) {
+		client := &mockECSClient{}
+		services := make([]string, 21)
+		for i := range services {
+			services[i] = fmt.Sprintf("service-%d", i)
+		}
+
+		_, err := fetchServicesMetadata(ctx, client, "cluster-1", services)
+		require.NoError(t, err)
+		assertBatched(t, client.DescribeServicesBatches, services, 10)
+	})
+}
+
+// Image tags are resolved from a map built out of every described task. Building that map one
+// batch at a time would leave tasks in later batches with an UNKNOWN tag.
+func Test_fetchContainersFromTasks_resolvesImageTagsAcrossBatches(t *testing.T) {
+	client := &mockECSClient{}
+	tasks := syntheticTaskARNs(101)
+
+	containers, err := fetchContainersFromTasks(context.Background(), client, "cluster-1", tasks)
+	require.NoError(t, err)
+	require.Len(t, containers, len(tasks))
+	require.Greater(t, len(client.DescribeTasksBatches), 1, "needs more than one batch to be meaningful")
+
+	for _, container := range containers {
+		assert.Equal(t, "app:v1", container.ImageTag)
 	}
 }

--- a/pkg/inventory/mock_ecs_test.go
+++ b/pkg/inventory/mock_ecs_test.go
@@ -3,6 +3,9 @@ package inventory
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ecs "github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -16,11 +19,42 @@ type mockECSClient struct {
 	ErrorOnDescribeTasks       bool
 	ErrorOnListTagsForResource bool
 	ErrorOnDescribeServices    bool
+
+	// Multi-page responses for the List* calls. When a field is nil the call returns its
+	// fixed single-page response instead, so tests that predate pagination are unaffected.
+	ClusterPages [][]string
+	TaskPages    [][]string
+	ServicePages [][]string
+
+	// The ID lists each Describe* call was made with, in order, so tests can check batching.
+	DescribeTasksBatches    [][]string
+	DescribeServicesBatches [][]string
 }
 
-func (m *mockECSClient) ListClusters(ctx context.Context, _ *ecs.ListClustersInput, _ ...func(*ecs.Options)) (*ecs.ListClustersOutput, error) {
+// pageOf returns the page the token points at, plus the token for the page after it. Tokens
+// are just the next page's index.
+func pageOf(pages [][]string, token *string) ([]string, *string) {
+	idx := 0
+	if token != nil {
+		idx, _ = strconv.Atoi(*token)
+	}
+	if idx >= len(pages) {
+		return nil, nil
+	}
+	var next *string
+	if idx+1 < len(pages) {
+		next = aws.String(strconv.Itoa(idx + 1))
+	}
+	return pages[idx], next
+}
+
+func (m *mockECSClient) ListClusters(ctx context.Context, input *ecs.ListClustersInput, _ ...func(*ecs.Options)) (*ecs.ListClustersOutput, error) {
 	if m.ErrorOnListCluster {
 		return nil, errors.New("list cluster error")
+	}
+	if m.ClusterPages != nil {
+		arns, next := pageOf(m.ClusterPages, input.NextToken)
+		return &ecs.ListClustersOutput{ClusterArns: arns, NextToken: next}, nil
 	}
 	return &ecs.ListClustersOutput{
 		ClusterArns: []string{
@@ -30,9 +64,13 @@ func (m *mockECSClient) ListClusters(ctx context.Context, _ *ecs.ListClustersInp
 	}, nil
 }
 
-func (m *mockECSClient) ListTasks(ctx context.Context, _ *ecs.ListTasksInput, _ ...func(*ecs.Options)) (*ecs.ListTasksOutput, error) {
+func (m *mockECSClient) ListTasks(ctx context.Context, input *ecs.ListTasksInput, _ ...func(*ecs.Options)) (*ecs.ListTasksOutput, error) {
 	if m.ErrorOnListTasks {
 		return nil, errors.New("list tasks error")
+	}
+	if m.TaskPages != nil {
+		arns, next := pageOf(m.TaskPages, input.NextToken)
+		return &ecs.ListTasksOutput{TaskArns: arns, NextToken: next}, nil
 	}
 	return &ecs.ListTasksOutput{
 		TaskArns: []string{
@@ -42,9 +80,13 @@ func (m *mockECSClient) ListTasks(ctx context.Context, _ *ecs.ListTasksInput, _ 
 	}, nil
 }
 
-func (m *mockECSClient) ListServices(ctx context.Context, _ *ecs.ListServicesInput, _ ...func(*ecs.Options)) (*ecs.ListServicesOutput, error) {
+func (m *mockECSClient) ListServices(ctx context.Context, input *ecs.ListServicesInput, _ ...func(*ecs.Options)) (*ecs.ListServicesOutput, error) {
 	if m.ErrorOnListServices {
 		return nil, errors.New("list services error")
+	}
+	if m.ServicePages != nil {
+		arns, next := pageOf(m.ServicePages, input.NextToken)
+		return &ecs.ListServicesOutput{ServiceArns: arns, NextToken: next}, nil
 	}
 	return &ecs.ListServicesOutput{
 		ServiceArns: []string{
@@ -54,12 +96,55 @@ func (m *mockECSClient) ListServices(ctx context.Context, _ *ecs.ListServicesInp
 	}, nil
 }
 
+const (
+	syntheticTaskPrefix = "synthetic-task-"
+	syntheticDigest     = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+)
+
+// syntheticTaskARNs builds a task list long enough to span more than one DescribeTasks batch.
+func syntheticTaskARNs(n int) []string {
+	arns := make([]string, n)
+	for i := range arns {
+		arns[i] = fmt.Sprintf("%s%d", syntheticTaskPrefix, i)
+	}
+	return arns
+}
+
+// Every synthetic task shares one image digest, but only the first carries the readable tag.
+// The rest can only be resolved from a tag map built across all of the batches at once.
+func syntheticTask(arn string) ecstypes.Task {
+	image := "app@" + syntheticDigest
+	if arn == syntheticTaskPrefix+"0" {
+		image = "app:v1"
+	}
+	return ecstypes.Task{
+		TaskArn:    aws.String(arn),
+		ClusterArn: aws.String("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1"),
+		TaskDefinitionArn: aws.String(
+			"arn:aws:ecs:us-east-1:123456789012:task-definition/task-definition-1:1",
+		),
+		Containers: []ecstypes.Container{
+			{
+				ContainerArn: aws.String("container-" + arn),
+				Name:         aws.String("container-" + arn),
+				Image:        aws.String(image),
+				ImageDigest:  aws.String(syntheticDigest),
+			},
+		},
+	}
+}
+
 func (m *mockECSClient) DescribeTasks(ctx context.Context, input *ecs.DescribeTasksInput, _ ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error) {
 	if m.ErrorOnDescribeTasks {
 		return nil, errors.New("describe tasks error")
 	}
+	m.DescribeTasksBatches = append(m.DescribeTasksBatches, input.Tasks)
 	tasks := []ecstypes.Task{}
 	for _, t := range input.Tasks {
+		if strings.HasPrefix(t, syntheticTaskPrefix) {
+			tasks = append(tasks, syntheticTask(t))
+			continue
+		}
 		switch t {
 		case "arn:aws:ecs:us-east-1:123456789012:task/cluster-1/12345678-1234-1234-1234-000000000000":
 			tasks = append(tasks, ecstypes.Task{
@@ -165,6 +250,7 @@ func (m *mockECSClient) DescribeServices(ctx context.Context, input *ecs.Describ
 	if m.ErrorOnDescribeServices {
 		return nil, errors.New("describe services error")
 	}
+	m.DescribeServicesBatches = append(m.DescribeServicesBatches, input.Services)
 
 	services := []ecstypes.Service{}
 	for _, s := range input.Services {


### PR DESCRIPTION
[ENTERPRISE-8894](https://anchore.atlassian.net/browse/ENTERPRISE-8894)

The agent read only the first page of ListClusters, ListTasks and ListServices, so clusters past 100, tasks past 100 and services past 10 were silently dropped from the inventory. Their images were never reported, so they were never scanned or evaluated against policy, and no error surfaced.

Follow every page using the SDK paginators, and split DescribeTasks/DescribeServices into the 100 and 10 ID batches those APIs accept. Both halves have to land together: paginating ListServices on its own would push more than 10 IDs into DescribeServices, which fails the request and drops the whole cluster report.

Two details worth noting:

- ListServices is given an explicit page size of 100. The paginator overwrites MaxResults set on the input with its own Limit, so setting it on the input has no effect and every page would come back with the default 10 services.

- DescribeTasks results are gathered across all batches before the image tag map is built. A per-batch map would lose tags for tasks whose readable tag lives in an earlier batch, degrading them to an UNKNOWN tag.

Both task describe call sites now share one helper rather than duplicating the call.

[ENTERPRISE-8894]: https://anchore.atlassian.net/browse/ENTERPRISE-8894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ